### PR TITLE
Split reason into multiple lore lines

### DIFF
--- a/src/net/zeppelin/reportplus/inventories/ReportListInventory.java
+++ b/src/net/zeppelin/reportplus/inventories/ReportListInventory.java
@@ -62,10 +62,12 @@ public class ReportListInventory extends ReportInventory
             Report tempReport = reports.get(i);
             String reporterName = tempReport.getReportPlayer().getName();
             String targetPlayerName = tempReport.getTargetPlayer().getName();
-
+	    
+	    String[] reason = tempReport.getReason().split("(?<=\\G.{15})");
             List<String> lore = new ArrayList<String>();
             lore.add("§6Reported By: §7" + reporterName);
-            lore.add("§6Reason: §7" + tempReport.getReason());
+            lore.add("§6Reason: §7" + reaason[0]);
+	    lore.addAll(Arrays.copyOfRange(reason, 1, reason.length));
             if (type == ACTIVE_REPORTS)
             {
                 if (tempReport.isClaimed())


### PR DESCRIPTION
This is to improve readability.
Note: I was not able to test this as the repo isn't setup with the dependencies needed in a POM file, etc.
This could be improved by getting the number of characters from a config file.